### PR TITLE
update tree-sitter dependencies and move it to workspace deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,5 +74,7 @@ ignore = "0.4"
 # Process execution
 which = "8.0"
 
+# CKG
+tree-sitter = "0.25"
 
 [patch.crates-io]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -51,15 +51,15 @@ coro_router = { package = "coro-router", git = "https://github.com/Blushyes/coro
 
 # Dependencies for moved tools
 jsonpath-rust = "0.7"
-tree-sitter = "0.24"
-tree-sitter-rust = "0.23"
-tree-sitter-python = "0.23"
-tree-sitter-javascript = "0.23"
+tree-sitter = { workspace = true }
+tree-sitter-rust = "0.24"
+tree-sitter-python = "0.25"
+tree-sitter-javascript = "0.25"
 tree-sitter-typescript = "0.23"
 tree-sitter-java = "0.23"
-tree-sitter-c = "0.23"
+tree-sitter-c = "0.24"
 tree-sitter-cpp = "0.23"
-tree-sitter-go = "0.23"
+tree-sitter-go = "0.25"
 rusqlite = { version = "0.32", features = ["bundled"] }
 walkdir = { workspace = true }
 ignore = { workspace = true }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -22,6 +22,7 @@ anyhow = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
+tree-sitter = { workspace = true }
 uuid = { workspace = true }
 chrono = { workspace = true }
 dirs = { workspace = true }
@@ -42,15 +43,6 @@ tempfile = "3.0"
 bytes = "1.0"
 async-openai = "0.29"
 jsonpath-rust = "0.7"
-tree-sitter = "0.24"
-tree-sitter-rust = "0.23"
-tree-sitter-python = "0.23"
-tree-sitter-javascript = "0.23"
-tree-sitter-typescript = "0.23"
-tree-sitter-java = "0.23"
-tree-sitter-c = "0.23"
-tree-sitter-cpp = "0.23"
-tree-sitter-go = "0.23"
 rusqlite = { version = "0.32", features = ["bundled"] }
 parking_lot = "0.12"
 


### PR DESCRIPTION
I was trying to use coro-core in a project that's already using ast-grep, but I ran into issues as the tree-sitter versions had conflict. It seems safe to upgrade the tree-sitter version. cargo check + tests still pass and the cli itself works as expected.

I also removed tree-sitter parsers from the core package as it was needed in cli only and moved tree-sitter to workspace deps.